### PR TITLE
Fix id when ref is created to be 'ref-' from 'col-'

### DIFF
--- a/lib/active_designer/public/js/schema/listeners.js
+++ b/lib/active_designer/public/js/schema/listeners.js
@@ -18,7 +18,7 @@ function destroyColumn() {
   $('.delete-column').unbind('click')
   $('.delete-column').click(function() {
     $(this).popover('dispose');
-    let column = $(this).parents("div[id^='col-']")[0];
+    let column = $(this).parents("li[id^='col-']")[0];
     let columnID = column.id;
     let card = $(this).parents(".card")[0];
     jsPlumb.remove(column)
@@ -41,7 +41,7 @@ function destroyReference() {
   $('.delete-ref').unbind('click')
   $('.delete-ref').click(function() {
     $(this).popover('dispose');
-    let reference = $(this).parents("div[id^='ref-']")[0];
+    let reference = $(this).parents("li[id^='ref-']")[0];
     let referenceID = reference.id;
     let tableID = `tbl-${referenceID.split('-')[1]}`;
     let card = $(this).parents(".card")[0];
@@ -83,7 +83,7 @@ function newRefObj(tableID,foreignTableName,foreignTableID, schema)  {
   if (columnIDs.length !== 0) {
     prevID = parseInt(columnIDs[columnIDs.length -1].split('-')[2]);
   }
-  let columnID = `col-${tableNum}-${prevID + 1}`;
+  let columnID = `ref-${tableNum}-${prevID + 1}`;
   return schema[tableID].references[columnID] = {
     id: columnID,
     table_id: tableID,
@@ -139,7 +139,6 @@ function createNewRef(schema,card) {
         let refObj = newRefObj(card[0].id, foreignTableName, foreignTableHTML[0].id, schema);
         listGroup.append(columnHTML({id: refObj.id, type: "integer", name: `${foreignTableName}_id`},"delete-ref"));
         let newColumnHTML = $(`#${refObj.id}`)[0]
-        // debugger
         createConnector(newColumnHTML,foreignKeyHTML);
       }
       else {

--- a/lib/active_designer/public/js/schema/main.js
+++ b/lib/active_designer/public/js/schema/main.js
@@ -9,7 +9,7 @@ $(document).ready(function() {
 
   function addReferences() {
     let schema = getSchema();
-    let refs = $("div[id^='ref-']");
+    let refs = $("li[id^='ref-']");
     for(let i = 0; i < refs.length; i++) {
       let referenceID = refs[i].id;
       let tableIDNum = referenceID.split('-')[1];


### PR DESCRIPTION
Fixed a bug that when a new reference is added the id that is stored is something like ref-100-101
instead of col-100-101